### PR TITLE
Disable local file resolution for parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
+    <relativePath />
   </parent>
 
   <groupId>com.google.common.geometry</groupId>


### PR DESCRIPTION
The parent repository, `oss-parent`, is an independent project and isn't
present locally.

`relativePath` defaults to `../`, which may point to unrelated project
if the repository is cloned into another maven project (e.g. as part of
a git submodules).